### PR TITLE
fix: Data in properties chart is not ordered

### DIFF
--- a/data-utils.js
+++ b/data-utils.js
@@ -361,6 +361,7 @@ export class DataUtils {
                 }
             }
         }
+        metrics.sort((a, b) => {return a.date - b.date});
 
         let data = this.prepareMetricsForLineChart(metrics, mode)
         return [ { data: data } ]


### PR DESCRIPTION
fix: data loaded from `.datascriptQuery` is not ordered