### PR TITLE
Feature: display several property metrics on one chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 yarn.lock
 package-lock.json
 .DS_Store
+*.sublime-*

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ The plugin also supports Child Metrics to allow logically similar Metrics to be 
 
 ## Usage 
 
-The plugin uses three slash commands: 
-- **Metrics Add** – Displays an interface to store a single Data Point for a Metric (and optionally a Child Metric) that you specify.  
-- **Metrics Visualize** – Displays an interface to insert a [Card](#card), [Bar Chart](#bar-chart) or [Line Chart](#line-chart) visualization into the current block on the current page.  
-- **Metrics Properties Chart** – Inserts a line chart that is populated from querying property values in your journal.  [more...](#properties-charts)
+The plugin uses three commands: 
+- **Metrics → Add** – Runs via `Command Palette` (⌘⇧P or Ctrl+Shift+P). Displays an interface to store a single Data Point for a Metric (and optionally a Child Metric) that you specify.  
+- **Metrics → Visualize** – `Slash-command` (type "/" while editing a block). Displays an interface to insert a [Card](#card), [Bar Chart](#bar-chart) or [Line Chart](#line-chart) visualization into the current block on the current page.  
+- **Metrics → Properties Chart** – `Slash-command` (type "/" while editing a block). Inserts a line chart that is populated from querying property values in your journal.  [more...](#properties-charts)
 
 ## Visualization Types
 
-You embed a visualization in your graph using the **Metrics Visualize** slash command.  
+You embed a visualization in your graph using the **Metrics → Visualize** slash-command.  
 
 ### Card
 A card displays a single value calcualted from the Data Points for a single Metric or Child Metric.  The following cards are supported:
@@ -51,7 +51,7 @@ The `metric` and `child metric` arguments refer to the Metric and Child Metric w
 - `cumulative-line` – Line Chart displaying the aggegate value of a Metric or Child Metrics over time 
 
 ### Data Storage
-Data for the metrics and data points is stored in the `metrics-plugin-data` page.  Each Metric, Child Meric and Data Point is stored on individual blocks on this page.  For example, storage of a Metric called *Movies Watched* with Child Metrics for *Comedy*, *Drama* and *Horror* movies is stored as follows: 
+Data for the metrics and data points is stored in the `metrics-plugin-data` page (could be changed in plugin settings).  Each Metric, Child Meric and Data Point is stored on individual blocks on this page.  For example, storage of a Metric called *Movies Watched* with Child Metrics for *Comedy*, *Drama* and *Horror* movies is stored as follows: 
 
 - Movies Watched  
 	- Comedy  
@@ -67,15 +67,18 @@ Data for the metrics and data points is stored in the `metrics-plugin-data` page
 
 Data points are stored as JSON objects with two attributes:
 - `date` – The date and time associated with the data point.  
-- `value` – The value of the data point.  It can be an integer, float or string.  If storing non-numeric data as a string, the only visualization that will work is the Latest Card (for example, you can use this to display a Card showing the name of the last book you read. 
+- `value` – The value of the data point.  It can be an integer, float or string.  If storing non-numeric data as a string, the only visualization that will work is the Latest Card (for example, you can use this to display a Card showing the name of the last book you read.
 
 ## Properties Charts
-A Properties Chart visualizes how [Logseq properties](https://discuss.logseq.com/t/lesson-5-how-to-power-your-workflows-using-properties-and-dynamic-variables/10173#what-are-logseq-properties-1) in your journal change over time.  To use this chart type first enter some numberic properties on your journal pages.  In the example below, there are entries for the `weight::` property on three journal pages.  
+A Properties Chart visualizes how [Logseq properties](https://discuss.logseq.com/t/lesson-5-how-to-power-your-workflows-using-properties-and-dynamic-variables/10173#what-are-logseq-properties-1) in your journal change over time.  To use this chart type first enter some numberic properties on your journal pages.  In the example below, there are entries for the `weight::` property on three journal pages.
+
+Use the **Metrics → Properties Chart** slash-command and enter the property name (`weight`) into the first argument of the renderer:
+`{{renderer :metrics, weight, -, properties-line}}`. The result looks like:
 
 ![PropertiesChart](./images/properties-chart.png)
 
-Then use the **Metrics Properties Chart** slash command and enter the property name (`weight`) into the first argument of the renderer:
-`{{renderer :metrics, weight, -, properties-line}}`
+Also several properties could be displayed on the same chart. Use a colon ":", a pipe "|" or a space " " to separate their names (! but NOT a comma ","): `{{renderer :metrics, weight | kcal, -, properties-line}}`.
+
 
 ## Feedback 
 I'd love to hear what you think of this plugin or if you have any suggestions for how to make it better!  Please [submit an issue](https://github.com/dangermccann/logseq-metrics/issues/new) on my Github to let share your feedback or to report bugs. 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,14 @@ async function main () {
     let addVizualizationUI = new AddVizualizationUI();
     addVizualizationUI.setUpUIHandlers();
 
-    logseq.Editor.registerSlashCommand("Metrics Add", async () => {
+    logseq.Editor.registerSlashCommand("Metrics → Add", async () => {
+        await logseq.Editor.insertAtEditingCursor("CHANGED: Use command palette to add new metric: ⌘+⇧+P or Ctrl+Shift+P");
+    })
+
+    logseq.App.registerCommandPalette({
+        key: 'metrics-add',
+        label: 'Metrics → Add',
+    }, async (e) => {
         addVizualizationUI.hide()
         addMetricUI.show()
         addMetricUI.clear()
@@ -51,7 +58,7 @@ async function main () {
         }, 200);
     })
 
-    logseq.Editor.registerSlashCommand("Metrics Visualize", async () => {
+    logseq.Editor.registerSlashCommand("Metrics → Visualize", async () => {
         addMetricUI.hide()
         addVizualizationUI.show()
         addVizualizationUI.clear()
@@ -65,8 +72,8 @@ async function main () {
         
     })
 
-    logseq.Editor.registerSlashCommand("Metrics Properties Chart", async () => { 
-        const content = `{{renderer :metrics, YOUR PROPERTY NAME HERE, -, properties-line}}`
+    logseq.Editor.registerSlashCommand("Metrics → Properties Chart", async () => { 
+        const content = '{{renderer :metrics, :property1 :property2, TITLE (use "-" to leave empty), properties-line}}'
 
         const block = await logseq.Editor.getCurrentBlock()
         if(block) {
@@ -75,7 +82,6 @@ async function main () {
             setTimeout(() => {
                 logseq.Editor.editBlock(block.uuid, { pos: 21 })
             }, 50)
-            
         }
     })
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "logseq-dateutils": "latest"
     },
     "logseq": {
-        "id": "logseq-metrics",
+        "id": "_logseq-metrics",
         "main": "dist/index.html",
         "icon": "./logo.png"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "logseq-metrics",
-    "version": "0.12",
+    "version": "0.13",
     "description": "Track and visaulize your personal habits, goals and business results in Logseq.",
     "author": "John McCann",
     "license": "MIT",
@@ -22,7 +22,7 @@
         "logseq-dateutils": "latest"
     },
     "logseq": {
-        "id": "_logseq-metrics",
+        "id": "logseq-metrics",
         "main": "dist/index.html",
         "icon": "./logo.png"
     },

--- a/settings.js
+++ b/settings.js
@@ -39,7 +39,9 @@ export const defaultSettings = {
         color_5: "#264653"
     },
     chart_height: 400,
-    add_to_journal: false
+    add_to_journal: false,
+    journal_title: "#Metrics ${metric}",
+    data_page_name: "metrics-plugin-data"
 }
 
 
@@ -48,29 +50,30 @@ export const defaultSettings = {
  * @param item
  * @returns {boolean}
  */
- export function isObject(item) {
+export function isObject(item) {
     return (item && typeof item === 'object' && !Array.isArray(item));
-  }
-  
-  /**
-   * Deep merge two objects.
-   * @param target
-   * @param ...sources
-   */
-  export function mergeDeep(target, ...sources) {
+}
+
+
+/**
+ * Deep merge two objects.
+ * @param target
+ * @param ...sources
+ */
+export function mergeDeep(target, ...sources) {
     if (!sources.length) return target;
     const source = sources.shift();
-  
+
     if (isObject(target) && isObject(source)) {
-      for (const key in source) {
-        if (isObject(source[key])) {
-          if (!target[key]) Object.assign(target, { [key]: {} });
-          mergeDeep(target[key], source[key]);
-        } else {
-          Object.assign(target, { [key]: source[key] });
+        for (const key in source) {
+            if (isObject(source[key])) {
+                if (!target[key]) Object.assign(target, { [key]: {} });
+                mergeDeep(target[key], source[key]);
+            } else {
+                Object.assign(target, { [key]: source[key] });
+            }
         }
-      }
     }
-  
+
     return mergeDeep(target, ...sources);
-  }
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1984175/216236549-b832cef2-702d-44fa-ae3d-f8bda3b4942f.png)

## And additional changes to improve user experience
- added setting "data_page_name" to set a data page for plugin
- added setting "journal_title" to set the template for adding metric record to journal, so we can change the related hash-tag
- changed a way of adding metric record to logseq journal (one metric record == one property), so we can use Properties Chart to visualize them
- changed a way of adding metric record to data page (via command palette, not slash-command), so there is no need to start editing a block now
- changed date formatting in point tooltip for properties chart (as of there is no need a time for those records, only a date)

