### PR TITLE
feature: second chart y-axis & plugin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A card displays a single value calcualted from the Data Points for a single Metr
 - Latest Value – Displays the most recent Data Point
 - Total Value – Dispalys the sum of all Data Points 
 - Average – Displays the average value of all Data Points
+- Count – Displays the count of all Data Points
 
 ![Card](./images/card.png)
 
@@ -66,6 +67,8 @@ Use the **Metrics → Properties Chart** slash-command and enter the property na
 ![PropertiesChart](./images/properties-chart.png)
 
 Also several properties could be displayed on the same chart. Use a colon ":", a pipe "|" or a space " " to separate their names (! but NOT a comma ","): `{{renderer :metrics, weight | kcal, -, properties-line}}`.
+
+If you need to display two completly different properties on the same chart: add a second y-axis by specifying asterisk `*` at the end of property name: `{{renderer :metrics, :weight :kcal*, -, properties-line}}`.
 
 
 ## Data Storage

--- a/data-utils.js
+++ b/data-utils.js
@@ -5,7 +5,7 @@ import {
     getDayInText,
     getScheduledDeadlineDateDay,
     getScheduledDeadlineDateDayTime,
-} from 'logseq-dateutils';
+} from 'logseq-dateutils'
 import {logseq as packageInfo} from './package.json'
 
 
@@ -34,7 +34,7 @@ export class Metric {
 
 export class DataUtils {
     constructor(_logseq) {
-        this.logseq = _logseq;
+        this.logseq = _logseq
     }
 
     async findBlock(tree, name) {
@@ -74,7 +74,7 @@ export class DataUtils {
 
         console.debug(`Loaded tree with ${tree.length} blocks`)
 
-        var blockId;
+        var blockId
         if(tree.length == 0) {
             console.debug(`Page is empty.  Inserting block ${name}`)
             blockId = (await this.logseq.Editor.appendBlockInPage(DATA_PAGE, name))?.uuid
@@ -116,7 +116,7 @@ export class DataUtils {
         else {
             console.log(`Metric inserted successfully: ${entry}`)
             
-            let formattedName = name;
+            let formattedName = name
             if(childName)
                 formattedName += " / " + childName
             
@@ -155,12 +155,12 @@ export class DataUtils {
     }
 
     prepareMetricsForLineChart(metrics, cumulativeMode) {
-        metrics = this.sortMetricsByDate(this.filterInvalidMetrics(metrics));
+        metrics = this.sortMetricsByDate(this.filterInvalidMetrics(metrics))
 
-        let data = [];
-        let sum = 0;
+        let data = []
+        let sum = 0
         metrics.forEach(metric => {
-            var date, value;
+            var date, value
             try {
                 let y = parseFloat(metric.value)
                 sum += y
@@ -172,7 +172,7 @@ export class DataUtils {
             
             data.push(value)
         })
-        return data;
+        return data
     }
 
     async loadLineChart(metricName, cumulativeMode) {
@@ -187,22 +187,23 @@ export class DataUtils {
         // Return value: 
         // datasets: [ { data: [ { x: (date), y: (float) } }, { ... } ] } ]
 
-        let datasets = []
-        let childNames = await this.loadMetricNames(metricName)
+        const datasets = []
+        const childNames = await this.loadMetricNames(metricName)
         if(childNames.length > 0) {
-            for(var i = 0; i < childNames.length; i++) {
-                var child = childNames[i];
-                let childName = child.label;
-                let metrics = await this.loadMetrics(metricName, childName)
-                datasets.push( { data: this.prepareMetricsForLineChart(metrics, cumulativeMode), label: childName } )
+            for(const { label } of childNames) {
+                const metrics = await this.loadMetrics(metricName, label)
+                datasets.push({
+                    data: this.prepareMetricsForLineChart(metrics, cumulativeMode),
+                    label: label,
+                })
             }
         }
         else {
-            let metrics = await this.loadMetrics(metricName)
+            const metrics = await this.loadMetrics(metricName)
             datasets.push( { data: this.prepareMetricsForLineChart(metrics, cumulativeMode) } )
         }
 
-        return datasets;
+        return datasets
     }
 
     // Remove any metrics that have non-numeric values or invalid dates
@@ -210,24 +211,24 @@ export class DataUtils {
         var filtered = []
         metrics.forEach(metric => {
             if(isNaN(parseFloat(metric.value)))
-                return;
+                return
             if(isNaN(new Date(metric.date).valueOf()))
-                return;
+                return
             filtered.push(metric)
         })
-        return filtered;
+        return filtered
     }
 
     // Chart.js requires data points to be sorted along the y-axis
     sortMetricsByDate(metrics) {
         var sorted = metrics.sort((a, b) => {
-            return new Date(a.date) - new Date(b.date);
+            return new Date(a.date) - new Date(b.date)
         })
-        return sorted;
+        return sorted
     }
 
     parseMetric(content) {
-        let parsed = null;
+        let parsed = null
         try {
             parsed = JSON.parse(content)
             if(parsed.value && parsed.date)
@@ -235,14 +236,14 @@ export class DataUtils {
 
         }
         finally {
-            return parsed;
+            return parsed
         }
     }
 
     async loadMetrics(metricName, childName) {
         const DATA_PAGE = this.logseq.settings.data_page_name
 
-        var block;
+        var block
         const tree = await this.logseq.Editor.getPageBlocksTree(DATA_PAGE)
         let blockId = await this.findBlock(tree, metricName)
         
@@ -257,8 +258,8 @@ export class DataUtils {
 
         block = await this.logseq.Editor.getBlock(blockId, { includeChildren: true })
 
-        let metrics = [];
-        var metric;
+        let metrics = []
+        var metric
         if(childName && childName.length > 0) {
             block?.children?.forEach( (child) => {
                 metric = this.parseMetric(child.content)
@@ -291,21 +292,21 @@ export class DataUtils {
 
     async loadChildMetrics(metricName) {
         console.log(`Loading child metrics for ${metricName}`)
-        var metrics = {};
+        var metrics = {}
     
         const DATA_PAGE = this.logseq.settings.data_page_name
         const tree = await this.logseq.Editor.getPageBlocksTree(DATA_PAGE)
     
-        console.debug(`Loaded tree: ${JSON.stringify(tree)}`);
+        console.debug(`Loaded tree: ${JSON.stringify(tree)}`)
     
         let blockId = await this.findBlock(tree, metricName)
         
-        if(!blockId) return metrics;
+        if(!blockId) return metrics
     
         var block = await this.logseq.Editor.getBlock(blockId, { includeChildren: true })
     
         block?.children?.forEach( (child) => {
-            let parsed = this.parseMetric(child.content);
+            let parsed = this.parseMetric(child.content)
             if(parsed) { 
                 // Only include child metrics
             }
@@ -319,7 +320,7 @@ export class DataUtils {
             }
         })
     
-        return metrics;
+        return metrics
     }
 
     // Returns list of top-level metric names if `parent` is null.  
@@ -363,28 +364,27 @@ export class DataUtils {
 
     async propertiesQueryLineChart(properties, cumulativeMode) {
         return Promise.all(properties.map(async (prop) => {
-            let results = await this.logseq.DB.datascriptQuery(`
-            [:find (pull ?b [*])
-              :where
-              [?b :block/page ?p]
-              [?p :block/journal? true]
-              [?b :block/properties ?prop]
-              [(get ?prop :${prop})]
-            ]`)        
+            const results = await this.logseq.DB.datascriptQuery(`
+                [:find (pull ?b [*])
+                  :where
+                  [?b :block/page ?p]
+                  [?p :block/journal? true]
+                  [?b :block/properties ?prop]
+                  [(get ?prop :${prop})]
+                ]
+            `)
 
-            if(!results) return { data: [] }
+            if(!results)
+                return { data: [] }
 
-            let metrics = []
-
-            for(var i = 0; i < results.length; i++) {
-                let result = results[i];
-                let value = parseFloat(result[0].properties[prop])
+            const metrics = []
+            for(const [ result ] of results) {
+                const value = parseFloat(result.properties[prop])
                 if(!isNaN(value)) {
-                    let pageId = result[0].page.id
-                    let page = await this.logseq.Editor.getPage(pageId)
+                    const page = await this.logseq.Editor.getPage(result.page.id)
                     if(page) {
-                        let day = page.journalDay.toString()
-                        let date = new Date(day.slice(0, 4) + '-' + day.slice(4, 6) + '-' + day.slice(6) + ' 00:00:00')
+                        const day = page.journalDay.toString()
+                        const date = new Date(day.slice(0, 4) + "-" + day.slice(4, 6) + "-" + day.slice(6) + " 00:00:00")
                         metrics.push(new Metric({ date: date, value: value }))
                     }
                 }
@@ -397,29 +397,69 @@ export class DataUtils {
         }))
     }
 
-    async addToJournal(name, child, metric) {
-        // See if the page exists
-        let config = await logseq.App.getUserConfigs()
-        let pageName = getDateForPageWithoutBrackets(new Date(metric.date), config.preferredDateFormat)
+    async addToJournal(name, child, metricObj) {
+        const config = await logseq.App.getUserConfigs()
+        const pageName = getDateForPageWithoutBrackets(new Date(metricObj.date), config.preferredDateFormat)
 
         let page = await logseq.Editor.getPage(pageName)
-        if(!page) {
+        if(!page) {  // See if the page exists
             console.log(`Creating page ${pageName}`)
             page = await logseq.Editor.createPage(pageName, {}, { createFirstBlock: true, journal: true, redirect: false })
         }
 
         let fullName = name
-        if(child) 
-            fullName += '/' + child
+        let property = this.clearPropertyName(name)
+        if(child) {
+            fullName += " / " + child
 
-        fullName = fullName.replaceAll(' ', '-')
+            // it seems like now @logseq/libs v0.0.14 have a bug: we cannot add property in the form "test/sub"
+            // so as a temporal solution used "test___sub": it can be renamed manually in Logseq
+            property += "___" + this.clearPropertyName(child)
+        }
 
-        let text = this.logseq.settings.journal_title.replaceAll('${metric}', fullName)
-        let block = await logseq.Editor.appendBlockInPage(page.uuid, text, {
-            properties: {
-                [fullName]: metric.value
+        const text = this.logseq.settings.journal_title.replaceAll("${metric}", fullName)
+
+        return await logseq.Editor.appendBlockInPage(
+            page.uuid,
+            text,
+            {
+                properties: {
+                    [property]: metricObj.value
+                }
             }
-        })
-        
+        )
+    }
+
+    clearName(name) {
+        // Idea: restric metric names with the same rules as Logseq restricts property names
+        // Property names restrictions from Logseq itself:
+
+        /**
+         * Property name begins with a non-numeric character and can contain alphanumeric characters
+         * and . * + ! - _ ? $ % & = < >.
+         * If -, + or . are the first character, the second character (if any) must be non-numeric.
+         */
+
+        // But this message is wrong for Logseq v0.8.16:
+        //   - ' is also allowed in property names
+        //   - property name can begins with numeric character
+        //   - property name can continues with numeric character after -, + or .
+        //   - property name can contain non-keyboard characters like ≈, §, ⌘, smiles, etc.
+
+        // So the real rule is:
+        //     Property name cannot contain keyboard characters :;,^@#()/\{}[]|"`~ and space
+
+        // Here, for metric (non-property) name we can restrict all these characters
+        // Except of space: because it is very usefull for naming
+        // But spaces should be cleaned in conversion to property
+
+        const restrictedChars = /[:;,^@#~"`/|\(){}[\]]/g
+
+        return name.replaceAll(restrictedChars, "")
+    }
+
+    clearPropertyName(name) {
+        return this.clearName(name).replaceAll(" ", "-").toLowerCase()
     }
 }
+

--- a/data-utils.js
+++ b/data-utils.js
@@ -154,7 +154,7 @@ export class DataUtils {
         return block?.uuid
     }
 
-    prepareMetricsForLineChart(metrics, mode) {
+    prepareMetricsForLineChart(metrics, cumulativeMode) {
         metrics = this.sortMetricsByDate(this.filterInvalidMetrics(metrics));
 
         let data = [];
@@ -165,7 +165,7 @@ export class DataUtils {
                 let y = parseFloat(metric.value)
                 sum += y
                 date = new Date(metric.date)
-                value = { x: date, y: (mode === 'cumulative') ? sum : y }
+                value = { x: date, y: cumulativeMode ? sum : y }
             } catch { 
                 console.debug(`Invalid meric.  date: ${metric.date}, value: ${metric.value}`)
             }
@@ -175,7 +175,7 @@ export class DataUtils {
         return data;
     }
 
-    async loadLineChart(metricName, mode) {
+    async loadLineChart(metricName, cumulativeMode) {
         // Scenarios:
         // 1. Single dataset using data from immediate children
         // 2. Multiple datasets where data comes from grandchildren 
@@ -194,12 +194,12 @@ export class DataUtils {
                 var child = childNames[i];
                 let childName = child.label;
                 let metrics = await this.loadMetrics(metricName, childName)
-                datasets.push( { data: this.prepareMetricsForLineChart(metrics, mode), label: childName } )
+                datasets.push( { data: this.prepareMetricsForLineChart(metrics, cumulativeMode), label: childName } )
             }
         }
         else {
             let metrics = await this.loadMetrics(metricName)
-            datasets.push( { data: this.prepareMetricsForLineChart(metrics, mode) } )
+            datasets.push( { data: this.prepareMetricsForLineChart(metrics, cumulativeMode) } )
         }
 
         return datasets;
@@ -284,6 +284,8 @@ export class DataUtils {
             })
         }
 
+        console.debug(`Loaded ${metrics.length} metrics`)
+
         return metrics
     }
 
@@ -359,7 +361,7 @@ export class DataUtils {
         return names
     }
 
-    async propertiesQueryLineChart(properties, mode) {
+    async propertiesQueryLineChart(properties, cumulativeMode) {
         return Promise.all(properties.map(async (prop) => {
             let results = await this.logseq.DB.datascriptQuery(`
             [:find (pull ?b [*])
@@ -390,7 +392,7 @@ export class DataUtils {
 
             return {
                 label: prop,
-                data: this.prepareMetricsForLineChart(metrics, mode),
+                data: this.prepareMetricsForLineChart(metrics, cumulativeMode),
             }
         }))
     }

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <form class="ml-0">
       <label class="block mb-3 relative">
         <span class="block text-sm font-medium text-slate-700 dark:text-slate-200">Metric Name</span>
+        <span class="text-sm font-light text-slate-600 dark:text-slate-300"> (don't use <span class="text-xs font-mono">:;,^@#()/\{}[]|"`~</span> characters)</span>
         <input type="text" class="mt-1 block w-full px-3 py-2 bg-slate-50 dark:bg-slate-500 border border-slate-300 rounded-md text-sm shadow-sm placeholder-slate-400
           focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500
           disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 import '@logseq/libs'
-import Chart from 'chart.js/auto';
-import 'chartjs-adapter-date-fns';
-import { DataUtils, Metric, logger } from './data-utils'
+import Chart from 'chart.js/auto'
+import 'chartjs-adapter-date-fns'
+import { AddMetricUI, AddVizualizationUI } from './ui.js'
+import { DataUtils, logger } from './data-utils'
 import { defaultSettings, mergeDeep } from './settings'
 
 
@@ -35,7 +36,7 @@ async function main() {
     const addMetricEl = document.getElementById('add-metric')
     if(!addMetricEl) {
         console.warn("Could not find main div")
-        return;
+        return
     }
 
     const addVisualizationEl = document.getElementById('visualize-metrics')
@@ -48,20 +49,19 @@ async function main() {
     // load settings, merge with defaults and save back so they can be modified by user
     logseq.updateSettings(mergeDeep({...defaultSettings}, logseq.settings))
 
-    // prepare UI for adding metrics
-    const addMetricUI = new AddMetricUI();
-    addMetricUI.setUpUIHandlers();
+    const addMetricUI = new AddMetricUI(Visualization.instances)
+    addMetricUI.setUpUIHandlers()
 
-    const addVizualizationUI = new AddVizualizationUI();
-    addVizualizationUI.setUpUIHandlers();
+    const addVizualizationUI = new AddVizualizationUI()
+    addVizualizationUI.setUpUIHandlers()
 
     logseq.Editor.registerSlashCommand("Metrics → Add", async () => {
-        await logseq.Editor.insertAtEditingCursor("CHANGED: Use command palette to add new metric: ⌘+⇧+P or Ctrl+Shift+P");
+        await logseq.Editor.insertAtEditingCursor("CHANGED: Use command palette to add new metric: ⌘+⇧+P or Ctrl+Shift+P")
     })
 
     logseq.App.registerCommandPalette({
-        key: 'metrics-add',
-        label: 'Metrics → Add',
+        key: "metrics-add",
+        label: "Metrics → Add",
     }, async (e) => {
         addVizualizationUI.hide()
         addMetricUI.show()
@@ -72,7 +72,7 @@ async function main() {
             addMetricEl.style.left = "50%"
             addMetricEl.style.top = "50%"
             addMetricUI.focus()    
-        }, 200);
+        }, 200)
     })
 
     logseq.Editor.registerSlashCommand("Metrics → Visualize", async () => {
@@ -85,8 +85,7 @@ async function main() {
             addVisualizationEl.style.left = "50%"
             addVisualizationEl.style.top = "50%"
             addVizualizationUI.focus()    
-        }, 200);
-        
+        }, 200)
     })
 
     logseq.Editor.registerSlashCommand("Metrics → Properties Chart", async () => { 
@@ -161,41 +160,42 @@ async function main() {
 
     logseq.provideStyle(`
         :root {
-          --metrics-bg-color1: var(--ls-primary-background-color);
-          --metrics-bg-color2: var(--ls-secondary-background-color);
-          --metrics-border-color: var(--ls-border-color);
-          --metrics-text-color: var(--ls-primary-text-color);
+            --metrics-bg-color1: var(--ls-primary-background-color);
+            --metrics-bg-color2: var(--ls-secondary-background-color);
+            --metrics-border-color: var(--ls-border-color);
+            --metrics-text-color: var(--ls-primary-text-color);
 
-          --metrics-color1: #0f9bd7;
-          --metrics-color2: #30b5a6;
-          --metrics-color3: #e6c700;
-          --metrics-color4: #e66f00;
-          --metrics-color5: #e2036b;
-          --metrics-color6: #8639ac;
-          --metrics-color7: #727274;
+            --metrics-color1: #0f9bd7;
+            --metrics-color2: #30b5a6;
+            --metrics-color3: #e6c700;
+            --metrics-color4: #e66f00;
+            --metrics-color5: #e2036b;
+            --metrics-color6: #8639ac;
+            --metrics-color7: #727274;
 
-          // Reserved for future use
-          // Nice idea, but not all themes adapt highlight vars (it is fresh feature)
-          // --metrics-color1: var(--ls-highlight-color-blue);
-          // --metrics-color2: var(--ls-highlight-color-green);
-          // --metrics-color3: var(--ls-highlight-color-yellow);
-          // --metrics-color4: var(--ls-highlight-color-red);
-          // --metrics-color5: var(--ls-highlight-color-pink);
-          // --metrics-color6: var(--ls-highlight-color-purple);
-          // --metrics-color7: var(--ls-highlight-color-gray);
+            // Reserved for future use
+            // Nice idea, but not all themes adapt highlight vars (it is fresh feature)
+            // --metrics-color1: var(--ls-highlight-color-blue);
+            // --metrics-color2: var(--ls-highlight-color-green);
+            // --metrics-color3: var(--ls-highlight-color-yellow);
+            // --metrics-color4: var(--ls-highlight-color-red);
+            // --metrics-color5: var(--ls-highlight-color-pink);
+            // --metrics-color6: var(--ls-highlight-color-purple);
+            // --metrics-color7: var(--ls-highlight-color-gray);
         }
 
         .metrics-card {
-          height: 11rem;
-          color: var(--metrics-text-color);
-          border-color: var(--metrics-border-color);
-          background-color: var(--metrics-bg-color1);
+            width: 11.4rem;
+            height: 9.4rem;
+            color: var(--metrics-text-color);
+            border-color: var(--metrics-border-color);
+            background-color: var(--metrics-bg-color1);
         }
         .metrics-card > div:nth-child(1) {
-          background-color: var(--metrics-bg-color2);
+            background-color: var(--metrics-bg-color2);
         }
         .metrics-card > div:nth-child(2) {
-          margin: auto;
+            margin: auto;
         }
 
         .metrics-chart {
@@ -211,14 +211,14 @@ async function main() {
 }
 
 
-function splitBy(text, delimeters=' |:') {
+function splitBy(text, delimeters=" |:") {
     text = text || ""
     if(!text)
         return []
 
     let chars = `[${delimeters}]+`
-    text = text.replace(new RegExp('^' + chars), '')
-    text = text.replace(new RegExp(chars + '$'), '')
+    text = text.replace(new RegExp("^" + chars), "")
+    text = text.replace(new RegExp(chars + "$"), "")
     return text.split(new RegExp(chars))
 }
 
@@ -227,10 +227,12 @@ class Visualization {
     static instances = {}
 
     static releaseAll() {
-        for (const blockInstances of Object.values(Visualization.instances))
+        for (const [ uuid, blockInstances ] of Object.entries(Visualization.instances)) {
             for (const viz of Object.values(blockInstances))
                 viz.release()
-        Visualization.instances = {}
+
+            delete Visualization.instances[uuid]
+        }
     }
 
     static create(uuid, slot, name, childName, visualization) {
@@ -240,16 +242,16 @@ class Visualization {
 
         name = name.trim()
         childName = childName.trim()
-        childName = childName === '-' ? '' : childName 
+        childName = childName === "-" ? "" : childName
         visualization = visualization.trim()
 
         const types = [
-            [CardVisualization, ['sum', 'average', 'latest']],
-            [ChartVisualization, [
-                'line', 'cumulative-line', 'bar',
-                'properties-line', 'properties-cumulative-line',
-            ]]
+            [CardVisualization, ["sum", "average", "latest", "count"]],
+            [BarChartVisualization, ["bar"]],
+            [MetricsLineChartVisualization, ["line", "cumulative-line"]],
+            [PropertiesLineChartVisualization, ["properties-line", "properties-cumulative-line"]],
         ]
+
         for (const [ cls, allowed ] of types) {
             if(allowed.includes(visualization)) {
                 instance = new cls(uuid, slot, name, childName, visualization)
@@ -278,7 +280,7 @@ class Visualization {
 
     constructor(uuid, slot, metric, childMetric, type) {
         if (this.constructor === Visualization)
-            throw new Error('Abstract class')
+            throw new Error("Abstract class")
 
         this.uuid = uuid
         this.slot = slot
@@ -301,23 +303,26 @@ class CardVisualization extends Visualization {
     async render() {
         const metrics = await dataUtils.loadMetrics(this.metric, this.childMetric)
 
-        console.log(`Loaded ${metrics.length} metrics.`)
-
         const [ title, calcFunc ] = {
             sum: ["Total", this.sum],
             average: ["Average", this.average],
             latest: ["Latest", this.latest],
+            count: ["Count", this.count],
         }[this.type]
 
-        const label = `${title} ${this.metric}${this.childMetric ? " / " + this.childMetric : ""}`
+        let name = this.metric
+        if(this.childMetric)
+            name += " / " + this.childMetric
+        name = name.replaceAll("-", " ").replaceAll(" ", "&nbsp;")
+
         const value = calcFunc.bind(this)(metrics)
 
         return `
-            <div class="metrics-card w-48 flex flex-col text-center border"
+            <div class="metrics-card flex flex-col text-center border"
                  data-uuid="${this.uuid}"
                  data-on-click="editBlock"
                 >
-                <div class="w-full text-lg p-2">${label}</div>
+                <div class="w-full text-lg p-2">${title} ${name}</div>
                 <div class="w-full text-4xl"><span>${value ? value : "—"}</span></div>
             </div>
         `.trim()
@@ -344,12 +349,21 @@ class CardVisualization extends Visualization {
 
         return dataUtils.sortMetricsByDate(metrics).slice(-1)[0].value
     }
+
+    count(metrics) {
+        return metrics.length
+    }
 }
 
 
-class ChartVisualization extends Visualization {
+class _ChartVisualization extends Visualization {
+    chartType = null
+
     constructor(uuid, slot, metric, childMetric, type) {
         super(uuid, slot, metric, childMetric, type)
+
+        if (this.constructor === _ChartVisualization)
+            throw new Error("Abstract class")
 
         this.chart = null
     }
@@ -383,36 +397,26 @@ class ChartVisualization extends Visualization {
 
         slotContainer.style.width = "100%"
 
-        if(this.type === 'bar')
-            this.chart = await this.bar()
-        else if(this.type === 'line')
-            this.chart = await this.line('metric', 'standard')
-        else if(this.type === 'cumulative-line')
-            this.chart = await this.line('metric', 'cumulative')
-        else if(this.type === 'properties-line')
-            this.chart = await this.line('properties', 'standard')
-        else if(this.type === 'properties-cumulative-line')
-            this.chart = await this.line('properties', 'cumulative')
-
+        this.chart = await this.getChart()
         return this.chart
     }
 
     getChartColors() {
         return cssVars([
-            '--metrics-color1',
-            '--metrics-color2',
-            '--metrics-color3',
-            '--metrics-color4',
-            '--metrics-color5',
-            '--metrics-color6',
-            '--metrics-color7',
+            "--metrics-color1",
+            "--metrics-color2",
+            "--metrics-color3",
+            "--metrics-color4",
+            "--metrics-color5",
+            "--metrics-color6",
+            "--metrics-color7",
         ])
     }
 
-    getChartOptions() {
+    async getChartOptions() {
         const [ textColor, borderColor ] = cssVars([
-            '--metrics-text-color',
-            '--metrics-border-color',
+            "--metrics-text-color",
+            "--metrics-border-color",
         ])
 
         return {
@@ -439,21 +443,23 @@ class ChartVisualization extends Visualization {
                     },
                     time: {}
                 },
-                yAxis: {
+                y1: {
+                    type: "linear",
+                    position: "left",
                     grid: {
                         tickColor: borderColor,
                         color: borderColor,
                         borderColor: borderColor,
                         drawBorder: true,
-                        drawTicks: false,
+                        drawTicks: true,
                         display: true
                     },
                     ticks: {
                         color: textColor,
                         padding: 10,
-                        backdropPadding: 10
+                        backdropPadding: 10,
                     }
-                }
+                },
             },
             plugins: {
                 title: {
@@ -470,80 +476,19 @@ class ChartVisualization extends Visualization {
         }
     }
 
-    async line(type, mode) {
-        const chartOptions = this.getChartOptions()
-        let datasets = []
-
-        if(type === 'metric') {
-            chartOptions.plugins.title.text = this.metric;
-            datasets = await dataUtils.loadLineChart(this.metric, mode);
-        }
-        else if(type === 'properties') {
-            let config = await logseq.App.getUserConfigs();
-            chartOptions.scales.xAxis.time.tooltipFormat = config.preferredDateFormat;
-
-            chartOptions.plugins.title.text = (this.childMetric === '-' ? '' : this.childMetric);
-            datasets = await dataUtils.propertiesQueryLineChart(splitBy(this.metric), mode);
-        }
-
-        const colors = this.getChartColors()
-        datasets.forEach((dataset, idx) => {
-            dataset.backgroundColor = dataset.borderColor = colors[idx % colors.length]
-        })
-
-        chartOptions.scales.xAxis.type = 'time';
-        chartOptions.scales.xAxis.time.unit = 'day';
-        chartOptions.elements = {
-            line: {
-                tension: 0.1
-            }
-        }
-
-        if(datasets.length > 1)
-            chartOptions.plugins.legend.display = true
-
-        const params = {
-            type: 'line',
-            data: {
-                datasets: datasets
-            },
-            options: chartOptions
-        }
-
-        return this._createChart(params)
+    async getData(options) {
+        throw new Error("Should be implemented in child class")
     }
 
-    async bar() {
-        const chartOptions = this.getChartOptions()
-
-        var metrics = await dataUtils.loadChildMetrics(this.metric)
-        var labels = []
-        var values = []
-
-        Object.keys(metrics).forEach((key) => {
-            labels.push(key)
-            var value = 0;
-
-            metrics[key].forEach((metric) => {
-                var num = Number.parseFloat(metric.value)
-                if(!isNaN(num))
-                    value += num
-            })
-
-            values.push(value)
-        })
-
+    async getChart() {
+        const options = await this.getChartOptions()
         const params = {
-            type: 'bar',
-            data: {
-                labels: labels,
-                datasets: [{
-                    data: values,
-                    backgroundColor: this.getChartColors()
-                }]
-            },
-            options: chartOptions
+            data: await this.getData(options),
+            options: options,
         }
+
+        if(this.chartType)
+            params.type = this.chartType
 
         return this._createChart(params)
     }
@@ -561,418 +506,157 @@ class ChartVisualization extends Visualization {
 }
 
 
-class AddMetricUI {
-    root;
-    metricNameInput;
-    childMetricInput;
-    dateInput;
-    timeInput;
-    valueInput;
-    autoComplete;
-    childAutoComplete;
-    autoCompleteData;
+class BarChartVisualization extends _ChartVisualization {
+    chartType = "bar"
 
-    constructor() {
-        this.root = document.getElementById("add-metric")
-        this.metricNameInput = document.getElementById("metric-name-input");
-        this.childMetricInput = document.getElementById("child-metric-input");
-        this.dateInput = document.getElementById("date-input");
-        this.timeInput = document.getElementById("time-input");
-        this.valueInput = document.getElementById("value-input");
-        this.autoComplete = document.getElementById("metric-name-auto-complete");
-        this.childAutoComplete = document.getElementById("child-metric-auto-complete");
-    
-        this.autoCompleteData = [ ]
+    async getData(options) {
+        var metrics = await dataUtils.loadChildMetrics(this.metric)
+        var labels = []
+        var values = []
+
+        Object.keys(metrics).forEach((key) => {
+            labels.push(key)
+            var value = 0
+
+            metrics[key].forEach((metric) => {
+                var num = Number.parseFloat(metric.value)
+                if(!isNaN(num))
+                    value += num
+            })
+
+            values.push(value)
+        })
+
+        return {
+            labels: labels,
+            datasets: [{
+                data: values,
+                backgroundColor: this.getChartColors()
+            }]
+        }
     }
+}
 
-    setUpUIHandlers() {
-        const _this = this;
-        document.addEventListener('keydown', function (e) {
-            //console.log(e.key)
-            if (e.keyCode === 27) {
-              logseq.hideMainUI({ restoreEditingCursor: true })
-            }
-            e.stopPropagation()
-        }, false)
 
-        document.getElementById("create-metrics-close-x")?.addEventListener('click', function (e) {
-            logseq.hideMainUI({ restoreEditingCursor: true })
-            e.stopPropagation()
-        }, false)
+class _LineChartVisualization extends _ChartVisualization {
+    chartType = "line"
 
-        document.getElementById("create-metrics-close-button")?.addEventListener('click', function (e) {
-            logseq.hideMainUI({ restoreEditingCursor: true })
-            e.stopPropagation()
-        }, false)
-
-        document.getElementById("create-metrics-enter-button")?.addEventListener('click', async function (e) {
-            if(_this.validate()) {
-                // add to metrics data page
-                await dataUtils.enterMetric(_this.metricNameInput.value, _this.childMetricInput.value, 
-                    _this.formatMetric())
-
-                // add to journal if checked
-                if(document.getElementById('journal-check').checked) {
-                    console.log("Will add to journal")
-                    await dataUtils.addToJournal(_this.metricNameInput.value, _this.childMetricInput.value, 
-                        JSON.parse(_this.formatMetric()))
+    async getChartOptions() {
+        const options = {
+            elements: {
+                line: {
+                    tension: 0.1
                 }
-
-                logseq.hideMainUI({ restoreEditingCursor: true })
-
-                for (const blockInstances of Object.values(Visualization.instances))
-                    for(const viz of Object.values(blockInstances))
-                        if(viz.metric === _this.metricNameInput.value)
-                            await refreshBlock(viz.uuid)
+            },
+            scales: {
+                xAxis: {
+                    type: "time",
+                    time: {
+                        unit: "day"
+                    }
+                }
             }
-            else 
-                console.log("Validation failed")
-            
-            e.stopPropagation()
-        }, false)
-
-        // Auto complete events
-        this.autoComplete.addEventListener('mousedown', function(e) {
-            e.stopPropagation()
-
-            if(!e.target.getAttribute('data-id'))
-                return;
-
-            _this.metricNameInput.value = e.target.textContent
-            _this.autoComplete.classList.add('hidden')
-        }, true)
-
-        this.metricNameInput.addEventListener('focus', function(e) { 
-            _this.prepareAutoComplete(null)
-        })
-
-        this.metricNameInput.addEventListener('blur', function(e) { 
-            _this.autoComplete.classList.add('hidden') 
-        })
-
-        this.metricNameInput.addEventListener('keyup', function(e) { 
-            AutoComplete.doAutoComplete(e, _this.autoComplete, _this.autoCompleteData)
-        })
-
-        // Child auto complete 
-        this.childAutoComplete.addEventListener('mousedown', function(e) {
-            e.stopPropagation()
-
-            if(!e.target.getAttribute('data-id'))
-                return;
-
-            _this.childMetricInput.value = e.target.textContent
-            _this.childAutoComplete.classList.add('hidden')
-        }, true)
-
-        this.childMetricInput.addEventListener('focus', function(e) { 
-            _this.prepareAutoComplete(_this.metricNameInput.value)
-        })
-
-        this.childMetricInput.addEventListener('blur', function(e) { 
-            _this.childAutoComplete.classList.add('hidden') 
-        })
-
-        this.childMetricInput.addEventListener('keyup', function(e) { 
-            AutoComplete.doAutoComplete(e, _this.childAutoComplete, _this.autoCompleteData)
-        })
-    }
-
-    async prepareAutoComplete(parent) {
-        this.autoCompleteData = await dataUtils.loadMetricNames(parent)
-    }
-
-    formatMetric() {
-        const date = new Date(`${this.dateInput.value} ${this.timeInput.value}`)
-        const val = { date: date, value: this.valueInput.value }
-        return JSON.stringify(val)
-    }
-
-    clear() {
-        this.metricNameInput.value = '';
-        this.childMetricInput.value = '';
-        this.valueInput.value = '';
-
-        document.getElementById('journal-check').checked = logseq.settings.add_to_journal || false
-
-        let now = new Date();
-        this.dateInput.value = now.toLocaleDateString('en-CA')
-        this.timeInput.value = now.toLocaleTimeString('en-GB')
-    }
-
-    focus() {
-        this.metricNameInput.focus()
-    }
-
-    validate() {
-        let returnVal = true;
-        if(!this.validateInputNotEmpty(this.metricNameInput))
-            returnVal = false
-        
-        if(!this.validateInputNotEmpty(this.dateInput))
-            returnVal = false
-
-        if(!this.validateInputNotEmpty(this.timeInput))
-            returnVal = false
-
-        if(!this.validateInputNotEmpty(this.valueInput))
-            returnVal = false
-
-        return returnVal
-    }
-
-    validateInputNotEmpty(input) {
-        if(input.value.length == 0) {
-            this.makeInputInvalid(input)
-            return false
         }
-        else {
-            this.makeInputValid(input)
-            return true
+
+        return mergeDeep(await super.getChartOptions(), options)
+    }
+
+    async loadData(options) {
+        throw new Error("Should be implemented in child class")
+    }
+
+    async getData(options) {
+        const datasets = await this.loadData(options)
+
+        const colors = this.getChartColors()
+        datasets.forEach((dataset, idx) => {
+            dataset.backgroundColor = dataset.borderColor = colors[idx % colors.length]
+        })
+
+        if(datasets.length > 1)
+            options.plugins.legend.display = true
+
+        return {
+            datasets: datasets
         }
-    }
-
-    makeInputInvalid(input) {
-        input.classList.remove("border-slate-300")
-        input.classList.remove("focus:ring-sky-500")
-        input.classList.remove("focus:border-sky-500")
-        input.classList.add("border-red-600")
-        input.classList.add("focus:ring-red-500")
-        input.classList.add("focus:border-red-500")
-    }
-
-    makeInputValid(input) {
-        input.classList.remove("border-red-600")
-        input.classList.remove("focus:ring-red-500")
-        input.classList.remove("focus:border-red-500")
-        input.classList.add("border-slate-300")
-        input.classList.add("focus:ring-sky-500")
-        input.classList.add("focus:border-sky-500")
-    }
-
-    show() {
-        this.root.classList.remove("hidden")
-    }
-
-    hide() {
-        this.root.classList.add("hidden")
     }
 }
 
 
-class AddVizualizationUI {
-    root;
-    metricNameInput;
-    childMetricInput;
-    vizSelect;
-    autoComplete;
-    childAutoComplete;
-    autoCompleteData;
+class MetricsLineChartVisualization extends _LineChartVisualization {
+    async getChartOptions() {
+        const options = {
+            plugins: {
+                title: {
+                    text: this.metric
+                }
+            }
+        }
 
-    constructor() {
-        this.root = document.getElementById("visualize-metrics")
-        this.metricNameInput = document.getElementById("visualize-metrics-name-input");
-        this.childMetricInput = document.getElementById("visualize-metrics-child-input");
-        this.vizSelect = document.getElementById("visualize-metrics-select");
-        this.autoComplete = document.getElementById("visualize-name-auto-complete");
-        this.childAutoComplete = document.getElementById("visualize-child-auto-complete");
-
-        this.autoComplete.classList.add('hidden') 
-        this.childAutoComplete.classList.add('hidden') 
-
-        this.autoCompleteData = []
+        return mergeDeep(super.getChartOptions(), options)
     }
 
-
-    setUpUIHandlers() {
-        const _this = this;
-
-        document.getElementById("visualize-metrics-close-x")?.addEventListener('click', function (e) {
-            logseq.hideMainUI({ restoreEditingCursor: true })
-            e.stopPropagation()
-        }, false)
-
-        document.getElementById("visualize-metrics-close-button")?.addEventListener('click', function (e) {
-            logseq.hideMainUI({ restoreEditingCursor: true })
-            e.stopPropagation()
-        }, false)
-
-        document.getElementById("visualize-metrics-enter-button")?.addEventListener('click', async function (e) {
-            let childName = _this.childMetricInput.value;
-            if(childName == "")
-                childName = "-"
-
-            let viz = _this.vizSelect.options[_this.vizSelect.selectedIndex].value
-
-            // Insert renderer
-            const content = `{{renderer :metrics, ${_this.metricNameInput.value}, ${childName}, ${viz}}}`
-
-            const block = await logseq.Editor.getCurrentBlock()
-            if(block)
-                await logseq.Editor.updateBlock(block.uuid, content)
-
-            
-            logseq.hideMainUI({ restoreEditingCursor: true })
-            
-            e.stopPropagation()
-        }, false)
-
-        document.getElementById("help-link")?.addEventListener('click', async function(e) {
-            console.log("opening link")
-            await logseq.App.openExternalLink('https://github.com/dangermccann/logseq-metrics#visualization-types')
-            return false;
-        })
-
-        // Auto complete events
-        this.autoComplete.addEventListener('mousedown', function(e) {
-            e.stopPropagation()
-
-            if(!e.target.getAttribute('data-id'))
-                return;
-
-            _this.metricNameInput.value = e.target.textContent
-            _this.autoComplete.classList.add('hidden')
-        }, true)
-
-        this.metricNameInput.addEventListener('focus', function(e) { 
-            _this.prepareAutoComplete(null)
-        })
-
-        this.metricNameInput.addEventListener('blur', function(e) { 
-            _this.autoComplete.classList.add('hidden') 
-        })
-
-        this.metricNameInput.addEventListener('keyup', function(e) { 
-            AutoComplete.doAutoComplete(e, _this.autoComplete, _this.autoCompleteData)
-        })
-
-        // Child auto complete 
-        this.childAutoComplete.addEventListener('mousedown', function(e) {
-            e.stopPropagation()
-
-            if(!e.target.getAttribute('data-id'))
-                return;
-
-            _this.childMetricInput.value = e.target.textContent
-            _this.childAutoComplete.classList.add('hidden')
-        }, true)
-
-        this.childMetricInput.addEventListener('focus', function(e) { 
-            _this.prepareAutoComplete(_this.metricNameInput.value)
-        })
-
-        this.childMetricInput.addEventListener('blur', function(e) { 
-            _this.childAutoComplete.classList.add('hidden') 
-        })
-
-        this.childMetricInput.addEventListener('keyup', function(e) { 
-            AutoComplete.doAutoComplete(e, _this.childAutoComplete, _this.autoCompleteData)
-        })
-
-    }
-
-    async prepareAutoComplete(parent) {
-        this.autoCompleteData = await dataUtils.loadMetricNames(parent)
-    }
-
-    clear() {
-        this.metricNameInput.value = '';
-        this.childMetricInput.value = '';
-    }
-
-    focus() {
-        this.metricNameInput.focus()
-    }
-
-    show() {
-        this.root.classList.remove("hidden")
-    }
-
-    hide() {
-        this.root.classList.add("hidden")
+    async loadData(options) {
+        const cumulativeMode = this.type.includes("cumulative-")
+        return await dataUtils.loadLineChart(this.metric, cumulativeMode)
     }
 }
 
 
-class AutoComplete {
-    static doAutoComplete(e, container, data) {
-        if(e.target.value == '') {
-            container.classList.add('hidden')
+class PropertiesLineChartVisualization extends _LineChartVisualization {
+    altAxisSuffix = "*"
+
+    async getChartOptions() {
+        const config = await logseq.App.getUserConfigs()
+        const title = this.childMetric
+
+        const options = {
+            scales: {
+                xAxis: {
+                    time: {
+                        tooltipFormat: config.preferredDateFormat
+                    }
+                }
+            },
+            plugins: {
+                title: {
+                    display: !!title,
+                    text: title
+                }
+            }
         }
-        else {
-            while (container.firstChild) {
-                container.removeChild(container.firstChild);
-            }
-            var results = [];
-            try {
-                results = AutoComplete.search(e.target.value, data)
-            }
-            catch(e) { }
 
-            if(results.length === 0) {
-                container.classList.add('hidden')
-                return
-            }
-            
-            let template = document.getElementById('auto-complete-template')
-
-            results.forEach((result) => {
-                let el = template.cloneNode(true)
-                el.setAttribute("data-id", result.id)
-                el.textContent = result.label
-                el.classList.remove('hidden')
-                container.appendChild(el)
-            })
-
-            container.classList.remove('hidden')
-        }
+        return mergeDeep(await super.getChartOptions(), options)
     }
 
-    static search(input, candidates) {
-        let inputTokens = input.split(' ')
-        let matches = []
-        let inputs = []
+    async loadData(options) {
+        const properties = splitBy(this.metric)
+        const cumulativeMode = this.type.includes("cumulative-")
+        const needAltAxis = p => p.endsWith(this.altAxisSuffix)
 
-        // Create reg expressions for each input token
-        inputTokens.forEach((inputToken) => {
-            inputs.push(new RegExp(inputToken, 'gi'))
-        })
+        const datasets = await dataUtils.propertiesQueryLineChart(
+            properties.map(p => p.replace(new RegExp("\\" + this.altAxisSuffix + "$"), "")),
+            cumulativeMode,
+        )
 
-        // Assign a score for each candidate
-        candidates.forEach((candidate) => {
-            let candidateScore = 0
-
-            let tokens = candidate.label.split(' ')
-            tokens.forEach((token) => {
-                inputs.forEach((rex) => {
-                    if(rex.test(token))
-                        candidateScore++
-                })
-            })
-
-            if(candidateScore > 0) {
-                matches.push({ 
-                    result: candidate,
-                    score: candidateScore
-                })
+        datasets.forEach((dataset, idx) => {
+            if (needAltAxis(properties[idx])) {
+                dataset.label = properties[idx]
+                dataset.yAxisID = "y2"
             }
         })
 
-        // Sort matches
-        matches = matches.sort((a, b) => {
-            return b.score - a.score;
-        })
+        if(properties.some(needAltAxis)) {
+            options.scales.y2 = {}
+            mergeDeep(options.scales.y2, options.scales.y1)
+            options.scales.y2.position = "right"
+        }
+        if(properties.every(needAltAxis))
+            delete options.scales.y1
 
-        // build array to return 
-        let returns = []
-        matches.forEach((match) => {
-            returns.push(match.result)
-        })
-
-        return returns
+        return datasets
     }
 }
 
 
-// bootstrap
 logseq.ready().then(main).catch(console.error)

--- a/output.css
+++ b/output.css
@@ -1,5 +1,5 @@
 /*
-! tailwindcss v3.2.4 | MIT License | https://tailwindcss.com
+! tailwindcss v3.2.6 | MIT License | https://tailwindcss.com
 */
 
 /*
@@ -521,16 +521,16 @@ video {
   position: relative;
 }
 
-.top-0 {
-  top: 0px;
+.left-0 {
+  left: 0px;
 }
 
 .right-0 {
   right: 0px;
 }
 
-.left-0 {
-  left: 0px;
+.top-0 {
+  top: 0px;
 }
 
 .z-10 {
@@ -542,6 +542,10 @@ video {
   margin-right: auto;
 }
 
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
 .mb-4 {
   margin-bottom: 1rem;
 }
@@ -550,32 +554,28 @@ video {
   margin-left: 0px;
 }
 
-.mb-3 {
-  margin-bottom: 0.75rem;
-}
-
-.mt-1 {
-  margin-top: 0.25rem;
-}
-
-.mr-1 {
-  margin-right: 0.25rem;
-}
-
-.mt-6 {
-  margin-top: 1.5rem;
-}
-
-.ml-3 {
-  margin-left: 0.75rem;
+.ml-1 {
+  margin-left: 0.25rem;
 }
 
 .ml-1\.5 {
   margin-left: 0.375rem;
 }
 
-.ml-1 {
-  margin-left: 0.25rem;
+.ml-3 {
+  margin-left: 0.75rem;
+}
+
+.mr-1 {
+  margin-right: 0.25rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
 }
 
 .block {
@@ -590,32 +590,32 @@ video {
   display: none;
 }
 
-.h-screen {
-  height: 100vh;
+.h-40 {
+  height: 10rem;
 }
 
 .h-6 {
   height: 1.5rem;
 }
 
-.h-40 {
-  height: 10rem;
+.h-screen {
+  height: 100vh;
 }
 
-.w-full {
-  width: 100%;
-}
-
-.w-80 {
-  width: 20rem;
+.w-5 {
+  width: 1.25rem;
 }
 
 .w-6 {
   width: 1.5rem;
 }
 
-.w-5 {
-  width: 1.25rem;
+.w-80 {
+  width: 20rem;
+}
+
+.w-full {
+  width: 100%;
 }
 
 .flex-1 {
@@ -644,16 +644,16 @@ video {
   white-space: nowrap;
 }
 
+.rounded-3xl {
+  border-radius: 1.5rem;
+}
+
 .rounded-lg {
   border-radius: 0.5rem;
 }
 
 .rounded-md {
   border-radius: 0.375rem;
-}
-
-.rounded-3xl {
-  border-radius: 1.5rem;
 }
 
 .border {
@@ -664,9 +664,9 @@ video {
   border-bottom-width: 1px;
 }
 
-.border-slate-300 {
+.border-red-600 {
   --tw-border-opacity: 1;
-  border-color: rgb(203 213 225 / var(--tw-border-opacity));
+  border-color: rgb(220 38 38 / var(--tw-border-opacity));
 }
 
 .border-slate-200 {
@@ -674,9 +674,14 @@ video {
   border-color: rgb(226 232 240 / var(--tw-border-opacity));
 }
 
-.border-red-600 {
+.border-slate-300 {
   --tw-border-opacity: 1;
-  border-color: rgb(220 38 38 / var(--tw-border-opacity));
+  border-color: rgb(203 213 225 / var(--tw-border-opacity));
+}
+
+.bg-gray-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(107 114 128 / var(--tw-bg-opacity));
 }
 
 .bg-slate-100 {
@@ -689,19 +694,18 @@ video {
   background-color: rgb(248 250 252 / var(--tw-bg-opacity));
 }
 
-.bg-white {
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
-}
-
 .bg-violet-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(124 58 237 / var(--tw-bg-opacity));
 }
 
-.bg-gray-500 {
+.bg-white {
   --tw-bg-opacity: 1;
-  background-color: rgb(107 114 128 / var(--tw-bg-opacity));
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.p-2 {
+  padding: 0.5rem;
 }
 
 .p-3 {
@@ -710,10 +714,6 @@ video {
 
 .p-4 {
   padding: 1rem;
-}
-
-.p-2 {
-  padding: 0.5rem;
 }
 
 .px-3 {
@@ -726,12 +726,12 @@ video {
   padding-bottom: 0.5rem;
 }
 
-.pt-2 {
-  padding-top: 0.5rem;
-}
-
 .pr-2 {
   padding-right: 0.5rem;
+}
+
+.pt-2 {
+  padding-top: 0.5rem;
 }
 
 .pt-3 {
@@ -742,9 +742,8 @@ video {
   text-align: center;
 }
 
-.text-xl {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .text-sm {
@@ -752,12 +751,22 @@ video {
   line-height: 1.25rem;
 }
 
-.font-medium {
-  font-weight: 500;
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
 }
 
 .font-light {
   font-weight: 300;
+}
+
+.font-medium {
+  font-weight: 500;
 }
 
 .font-semibold {
@@ -768,9 +777,9 @@ video {
   line-height: 1.25rem;
 }
 
-.text-slate-800 {
+.text-slate-600 {
   --tw-text-opacity: 1;
-  color: rgb(30 41 59 / var(--tw-text-opacity));
+  color: rgb(71 85 105 / var(--tw-text-opacity));
 }
 
 .text-slate-700 {
@@ -778,9 +787,9 @@ video {
   color: rgb(51 65 85 / var(--tw-text-opacity));
 }
 
-.text-slate-600 {
+.text-slate-800 {
   --tw-text-opacity: 1;
-  color: rgb(71 85 105 / var(--tw-text-opacity));
+  color: rgb(30 41 59 / var(--tw-text-opacity));
 }
 
 .text-white {
@@ -798,23 +807,23 @@ video {
   color: rgb(148 163 184 / var(--tw-placeholder-opacity));
 }
 
-.opacity-60 {
-  opacity: 0.6;
-}
-
 .opacity-20 {
   opacity: 0.2;
 }
 
-.shadow-xl {
-  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+.opacity-60 {
+  opacity: 0.6;
 }
 
 .shadow-sm {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -837,11 +846,6 @@ html, body {
   color-scheme: dark;
 }
 
-.hover\:bg-violet-500:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(139 92 246 / var(--tw-bg-opacity));
-}
-
 .hover\:bg-gray-400:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(156 163 175 / var(--tw-bg-opacity));
@@ -850,6 +854,11 @@ html, body {
 .hover\:bg-slate-600:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(71 85 105 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-violet-500:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(139 92 246 / var(--tw-bg-opacity));
 }
 
 .hover\:text-white:hover {
@@ -861,14 +870,14 @@ html, body {
   opacity: 1;
 }
 
-.focus\:border-sky-500:focus {
-  --tw-border-opacity: 1;
-  border-color: rgb(14 165 233 / var(--tw-border-opacity));
-}
-
 .focus\:border-red-500:focus {
   --tw-border-opacity: 1;
   border-color: rgb(239 68 68 / var(--tw-border-opacity));
+}
+
+.focus\:border-sky-500:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(14 165 233 / var(--tw-border-opacity));
 }
 
 .focus\:outline-none:focus {
@@ -882,14 +891,14 @@ html, body {
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 
-.focus\:ring-sky-500:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(14 165 233 / var(--tw-ring-opacity));
-}
-
 .focus\:ring-red-500:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(239 68 68 / var(--tw-ring-opacity));
+}
+
+.focus\:ring-sky-500:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(14 165 233 / var(--tw-ring-opacity));
 }
 
 .disabled\:border-slate-200:disabled {
@@ -923,24 +932,19 @@ html, body {
   border-color: rgb(100 116 139 / var(--tw-border-opacity));
 }
 
-.dark .dark\:bg-slate-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(71 85 105 / var(--tw-bg-opacity));
-}
-
 .dark .dark\:bg-slate-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(100 116 139 / var(--tw-bg-opacity));
 }
 
+.dark .dark\:bg-slate-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(71 85 105 / var(--tw-bg-opacity));
+}
+
 .dark .dark\:bg-slate-700 {
   --tw-bg-opacity: 1;
   background-color: rgb(51 65 85 / var(--tw-bg-opacity));
-}
-
-.dark .dark\:text-slate-50 {
-  --tw-text-opacity: 1;
-  color: rgb(248 250 252 / var(--tw-text-opacity));
 }
 
 .dark .dark\:text-slate-200 {
@@ -951,6 +955,11 @@ html, body {
 .dark .dark\:text-slate-300 {
   --tw-text-opacity: 1;
   color: rgb(203 213 225 / var(--tw-text-opacity));
+}
+
+.dark .dark\:text-slate-50 {
+  --tw-text-opacity: 1;
+  color: rgb(248 250 252 / var(--tw-text-opacity));
 }
 
 .dark .dark\:text-white {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "logseq-metrics",
-    "version": "0.14",
+    "version": "0.15",
     "description": "Track and visaulize your personal habits, goals and business results in Logseq.",
     "author": "John McCann",
     "license": "MIT",
@@ -9,16 +9,16 @@
         "clean": "rm -rf ./dist/*",
         "build-css": "tailwindcss -i ./index.css -o ./output.css",
         "build": "npm run clean && npm run build-css && parcel build --public-url . --no-optimize index.html",
-        "prod":  "npm run clean && npm run build-css && parcel build --public-url . --no-source-maps index.html"
+        "prod": "npm run clean && npm run build-css && parcel build --public-url . --no-source-maps index.html"
     },
     "devDependencies": {
-        "parcel": "^2.0.0",
-        "tailwindcss": "^3.1.8"
+        "parcel": "^2.8.3",
+        "tailwindcss": "^3.2.6"
     },
     "dependencies": {
-        "@logseq/libs": "^0.0.9",
-        "chart.js": "^3.9.1",
-        "chartjs-adapter-date-fns": "^2.0.0",
+        "@logseq/libs": "^0.0.14",
+        "chart.js": "^4.2.0",
+        "chartjs-adapter-date-fns": "^3.0.0",
         "date-fns": "^2.29.3",
         "logseq-dateutils": "latest"
     },
@@ -31,6 +31,6 @@
     "title": "Metrics",
     "effect": false,
     "sponsors": [
-      "https://www.buymeacoffee.com/dangermccaC"
+        "https://www.buymeacoffee.com/dangermccaC"
     ]
 }

--- a/settings.js
+++ b/settings.js
@@ -1,9 +1,33 @@
-export const defaultSettings = {
-    chart_height: 400,
-    add_to_journal: false,
-    journal_title: "#Metrics ${metric}",
-    data_page_name: "metrics-plugin-data"
-}
+export const settingsDescription = [
+  {
+    key: "chart_height",
+    type: "number",
+    title: "Height of all charts in pixels",
+    description: "Width selects automatically based on window size, theme settings and wide mode. You only need to specify height.",
+    default: 400,
+  },
+  {
+    key: "add_to_journal",
+    type: "boolean",
+    title: 'Checkbox state in add metric UI',
+    description: 'Wether "Also add entry to Journal" checked or not by default',
+    default: true,
+  },
+  {
+    key: "journal_title",
+    type: "string",
+    title: "When entry adds to journal it comes along with this string",
+    description: "Placeholder ${metric} can be used here: it will be replaced with metric name. Hint: stay some hashtag here to easily find all journal metrics. Only affects new entries.",
+    default: "#Metrics ${metric}",
+  },
+  {
+    key: "data_page_name",
+    type: "string",
+    title: "Plugin stores all metrics data in special page with this name",
+    description: "⚠️ If you change this settings and you already have entered some metrics data, you need to move it to new page manually!",
+    default: "metrics-plugin-data",
+  },
+]
 
 
 /**

--- a/ui.js
+++ b/ui.js
@@ -311,15 +311,15 @@ export class AddVizualizationUI {
             _this.autoComplete.classList.add("hidden")
         }, true)
 
-        this.metricNameInput.addEventListener("focus", function(e) { 
+        this.metricNameInput.addEventListener("focus", function(e) {
             _this.prepareAutoComplete(null)
         })
 
-        this.metricNameInput.addEventListener("blur", function(e) { 
+        this.metricNameInput.addEventListener("blur", function(e) {
             _this.autoComplete.classList.add("hidden") 
         })
 
-        this.metricNameInput.addEventListener("keyup", function(e) { 
+        this.metricNameInput.addEventListener("keyup", function(e) {
             AutoComplete.doAutoComplete(e, _this.autoComplete, _this.autoCompleteData)
         })
 

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,427 @@
+import '@logseq/libs'
+import { DataUtils, logger } from './data-utils'
+
+
+var dataUtils
+console = logger
+
+
+export class AddMetricUI {
+    root;
+    metricNameInput;
+    childMetricInput;
+    dateInput;
+    timeInput;
+    valueInput;
+    autoComplete;
+    childAutoComplete;
+    autoCompleteData;
+
+    constructor(visualizationInstances) {
+        this.root = document.getElementById("add-metric")
+        this.metricNameInput = document.getElementById("metric-name-input")
+        this.childMetricInput = document.getElementById("child-metric-input")
+        this.dateInput = document.getElementById("date-input")
+        this.timeInput = document.getElementById("time-input")
+        this.valueInput = document.getElementById("value-input")
+        this.autoComplete = document.getElementById("metric-name-auto-complete")
+        this.childAutoComplete = document.getElementById("child-metric-auto-complete")
+    
+        this.autoCompleteData = []
+
+        if(!dataUtils)
+            dataUtils = new DataUtils(logseq)
+
+        this.visualizationInstances = visualizationInstances
+    }
+
+    setUpUIHandlers() {
+        const _this = this
+
+        document.addEventListener("keydown", function (e) {
+            //console.log(e.key)
+            if (e.keyCode === 27) {
+              logseq.hideMainUI({ restoreEditingCursor: true })
+            }
+            e.stopPropagation()
+        }, false)
+
+        document.getElementById("create-metrics-close-x")?.addEventListener("click", function (e) {
+            logseq.hideMainUI({ restoreEditingCursor: true })
+            e.stopPropagation()
+        }, false)
+
+        document.getElementById("create-metrics-close-button")?.addEventListener("click", function (e) {
+            logseq.hideMainUI({ restoreEditingCursor: true })
+            e.stopPropagation()
+        }, false)
+
+        document.getElementById("create-metrics-enter-button")?.addEventListener("click", async function (e) {
+            if(_this.validate()) {
+                // add to metrics data page
+                await dataUtils.enterMetric(_this.metricNameInput.value, _this.childMetricInput.value, 
+                    _this.formatMetric())
+
+                // add to journal if checked
+                if(document.getElementById("journal-check").checked) {
+                    console.log("Will add to journal")
+                    await dataUtils.addToJournal(_this.metricNameInput.value, _this.childMetricInput.value, 
+                        JSON.parse(_this.formatMetric()))
+                }
+
+                logseq.hideMainUI({ restoreEditingCursor: true })
+
+                for (const blockInstances of Object.values(this.visualizationInstances))
+                    for(const viz of Object.values(blockInstances))
+                        if(viz.metric === _this.metricNameInput.value)
+                            await refreshBlock(viz.uuid)
+            }
+            else 
+                console.log("Validation failed")
+            
+            e.stopPropagation()
+        }, false)
+
+        // Auto complete events
+        this.autoComplete.addEventListener("mousedown", function(e) {
+            e.stopPropagation()
+
+            if(!e.target.getAttribute("data-id"))
+                return
+
+            _this.metricNameInput.value = e.target.textContent
+            _this.autoComplete.classList.add("hidden")
+        }, true)
+
+        this.metricNameInput.addEventListener("focus", function(e) { 
+            _this.prepareAutoComplete(null)
+        })
+
+        this.metricNameInput.addEventListener("blur", function(e) { 
+            _this.autoComplete.classList.add("hidden") 
+        })
+
+        this.metricNameInput.addEventListener("keyup", function(e) { 
+            AutoComplete.doAutoComplete(e, _this.autoComplete, _this.autoCompleteData)
+        })
+
+        // Child auto complete 
+        this.childAutoComplete.addEventListener("mousedown", function(e) {
+            e.stopPropagation()
+
+            if(!e.target.getAttribute("data-id"))
+                return
+
+            _this.childMetricInput.value = e.target.textContent
+            _this.childAutoComplete.classList.add("hidden")
+        }, true)
+
+        this.childMetricInput.addEventListener("focus", function(e) { 
+            _this.prepareAutoComplete(_this.metricNameInput.value)
+        })
+
+        this.childMetricInput.addEventListener("blur", function(e) { 
+            _this.childAutoComplete.classList.add("hidden") 
+        })
+
+        this.childMetricInput.addEventListener("keyup", function(e) { 
+            AutoComplete.doAutoComplete(e, _this.childAutoComplete, _this.autoCompleteData)
+        })
+    }
+
+    async prepareAutoComplete(parent) {
+        this.autoCompleteData = await dataUtils.loadMetricNames(parent)
+    }
+
+    formatMetric() {
+        const date = new Date(`${this.dateInput.value} ${this.timeInput.value}`)
+        const val = { date: date, value: this.valueInput.value }
+        return JSON.stringify(val)
+    }
+
+    clear() {
+        this.metricNameInput.value = ""
+        this.childMetricInput.value = ""
+        this.valueInput.value = ""
+
+        document.getElementById("journal-check").checked = logseq.settings.add_to_journal || false
+
+        let now = new Date()
+        this.dateInput.value = now.toLocaleDateString("en-CA")
+        this.timeInput.value = now.toLocaleTimeString("en-GB")
+    }
+
+    focus() {
+        this.metricNameInput.focus()
+    }
+
+    validate() {
+        let returnVal = true
+
+        if(!this.validateInputNotEmpty(this.metricNameInput))
+            returnVal = false
+        
+        if(!this.validateInputNotEmpty(this.dateInput))
+            returnVal = false
+
+        if(!this.validateInputNotEmpty(this.timeInput))
+            returnVal = false
+
+        if(!this.validateInputNotEmpty(this.valueInput))
+            returnVal = false
+
+        return returnVal
+    }
+
+    validateInputNotEmpty(input) {
+        if(input.value.length == 0) {
+            this.makeInputInvalid(input)
+            return false
+        }
+        else {
+            this.makeInputValid(input)
+            return true
+        }
+    }
+
+    makeInputInvalid(input) {
+        input.classList.remove("border-slate-300")
+        input.classList.remove("focus:ring-sky-500")
+        input.classList.remove("focus:border-sky-500")
+        input.classList.add("border-red-600")
+        input.classList.add("focus:ring-red-500")
+        input.classList.add("focus:border-red-500")
+    }
+
+    makeInputValid(input) {
+        input.classList.remove("border-red-600")
+        input.classList.remove("focus:ring-red-500")
+        input.classList.remove("focus:border-red-500")
+        input.classList.add("border-slate-300")
+        input.classList.add("focus:ring-sky-500")
+        input.classList.add("focus:border-sky-500")
+    }
+
+    show() {
+        this.root.classList.remove("hidden")
+    }
+
+    hide() {
+        this.root.classList.add("hidden")
+    }
+}
+
+
+export class AddVizualizationUI {
+    root;
+    metricNameInput;
+    childMetricInput;
+    vizSelect;
+    autoComplete;
+    childAutoComplete;
+    autoCompleteData;
+
+    constructor() {
+        this.root = document.getElementById("visualize-metrics")
+        this.metricNameInput = document.getElementById("visualize-metrics-name-input")
+        this.childMetricInput = document.getElementById("visualize-metrics-child-input")
+        this.vizSelect = document.getElementById("visualize-metrics-select")
+        this.autoComplete = document.getElementById("visualize-name-auto-complete")
+        this.childAutoComplete = document.getElementById("visualize-child-auto-complete")
+
+        this.autoComplete.classList.add("hidden") 
+        this.childAutoComplete.classList.add("hidden") 
+
+        this.autoCompleteData = []
+
+        if(!dataUtils)
+            dataUtils = new DataUtils(logseq)
+    }
+
+    setUpUIHandlers() {
+        const _this = this
+
+        document.getElementById("visualize-metrics-close-x")?.addEventListener("click", function (e) {
+            logseq.hideMainUI({ restoreEditingCursor: true })
+            e.stopPropagation()
+        }, false)
+
+        document.getElementById("visualize-metrics-close-button")?.addEventListener("click", function (e) {
+            logseq.hideMainUI({ restoreEditingCursor: true })
+            e.stopPropagation()
+        }, false)
+
+        document.getElementById("visualize-metrics-enter-button")?.addEventListener("click", async function (e) {
+            let childName = _this.childMetricInput.value
+            if(childName == "")
+                childName = "-"
+
+            let viz = _this.vizSelect.options[_this.vizSelect.selectedIndex].value
+
+            // Insert renderer
+            const content = `{{renderer :metrics, ${_this.metricNameInput.value}, ${childName}, ${viz}}}`
+
+            const block = await logseq.Editor.getCurrentBlock()
+            if(block)
+                await logseq.Editor.updateBlock(block.uuid, content)
+
+            
+            logseq.hideMainUI({ restoreEditingCursor: true })
+            
+            e.stopPropagation()
+        }, false)
+
+        document.getElementById("help-link")?.addEventListener("click", async function(e) {
+            console.log("opening link")
+            await logseq.App.openExternalLink("https://github.com/dangermccann/logseq-metrics#visualization-types")
+            return false
+        })
+
+        // Auto complete events
+        this.autoComplete.addEventListener("mousedown", function(e) {
+            e.stopPropagation()
+
+            if(!e.target.getAttribute("data-id"))
+                return
+
+            _this.metricNameInput.value = e.target.textContent
+            _this.autoComplete.classList.add("hidden")
+        }, true)
+
+        this.metricNameInput.addEventListener("focus", function(e) { 
+            _this.prepareAutoComplete(null)
+        })
+
+        this.metricNameInput.addEventListener("blur", function(e) { 
+            _this.autoComplete.classList.add("hidden") 
+        })
+
+        this.metricNameInput.addEventListener("keyup", function(e) { 
+            AutoComplete.doAutoComplete(e, _this.autoComplete, _this.autoCompleteData)
+        })
+
+        // Child auto complete 
+        this.childAutoComplete.addEventListener("mousedown", function(e) {
+            e.stopPropagation()
+
+            if(!e.target.getAttribute("data-id"))
+                return
+
+            _this.childMetricInput.value = e.target.textContent
+            _this.childAutoComplete.classList.add("hidden")
+        }, true)
+
+        this.childMetricInput.addEventListener("focus", function(e) { 
+            _this.prepareAutoComplete(_this.metricNameInput.value)
+        })
+
+        this.childMetricInput.addEventListener("blur", function(e) { 
+            _this.childAutoComplete.classList.add("hidden") 
+        })
+
+        this.childMetricInput.addEventListener("keyup", function(e) { 
+            AutoComplete.doAutoComplete(e, _this.childAutoComplete, _this.autoCompleteData)
+        })
+
+    }
+
+    async prepareAutoComplete(parent) {
+        this.autoCompleteData = await dataUtils.loadMetricNames(parent)
+    }
+
+    clear() {
+        this.metricNameInput.value = ""
+        this.childMetricInput.value = ""
+    }
+
+    focus() {
+        this.metricNameInput.focus()
+    }
+
+    show() {
+        this.root.classList.remove("hidden")
+    }
+
+    hide() {
+        this.root.classList.add("hidden")
+    }
+}
+
+
+export class AutoComplete {
+    static doAutoComplete(e, container, data) {
+        if(e.target.value === "") {
+            container.classList.add("hidden")
+        } else {
+            while (container.firstChild)
+                container.removeChild(container.firstChild)
+
+            var results = []
+            try {
+                results = AutoComplete.search(e.target.value, data)
+            }
+            catch(e) { }
+
+            if(results.length === 0) {
+                container.classList.add("hidden")
+                return
+            }
+            
+            let template = document.getElementById("auto-complete-template")
+
+            results.forEach((result) => {
+                let el = template.cloneNode(true)
+                el.setAttribute("data-id", result.id)
+                el.textContent = result.label
+                el.classList.remove("hidden")
+                container.appendChild(el)
+            })
+
+            container.classList.remove("hidden")
+        }
+    }
+
+    static search(input, candidates) {
+        let inputTokens = input.split(" ")
+        let matches = []
+        let inputs = []
+
+        // Create reg expressions for each input token
+        inputTokens.forEach((inputToken) => {
+            inputs.push(new RegExp(inputToken, "gi"))
+        })
+
+        // Assign a score for each candidate
+        candidates.forEach((candidate) => {
+            let candidateScore = 0
+
+            let tokens = candidate.label.split(" ")
+            tokens.forEach((token) => {
+                inputs.forEach((rex) => {
+                    if(rex.test(token))
+                        candidateScore++
+                })
+            })
+
+            if(candidateScore > 0) {
+                matches.push({ 
+                    result: candidate,
+                    score: candidateScore
+                })
+            }
+        })
+
+        // Sort matches
+        matches = matches.sort((a, b) => {
+            return b.score - a.score
+        })
+
+        // build array to return 
+        let returns = []
+        matches.forEach((match) => {
+            returns.push(match.result)
+        })
+
+        return returns
+    }
+}


### PR DESCRIPTION
## Possibility to use second chart y-axis
Use asterisk `*` after property name to mark it to display on second y-axis.

### Only left y-axis
`{{renderer :metrics, :blocks :references, My Logseq graph growth over the time, properties-line}}`

<img src="https://user-images.githubusercontent.com/1984175/217838324-8b72a779-a5e9-4567-9116-dadd4f3e730f.png" width="700"/>

### Left & right y-axis
`{{renderer :metrics, :blocks :references*, My Logseq graph growth over the time, properties-line}}`

<img src="https://user-images.githubusercontent.com/1984175/217838556-4924d4e6-54c6-45e7-a1aa-2b04089d3f0e.png" width="700"/>

### Only right y-axis
`{{renderer :metrics, :blocks* :references*, My Logseq graph growth over the time, properties-line}}`

<img src="https://user-images.githubusercontent.com/1984175/217838631-a1295d9b-e908-422e-be2b-ce7a9cfb5731.png" width="700"/>


## Setup plugin settings UI integration
<img src="https://user-images.githubusercontent.com/1984175/217840729-2da28d2d-2b27-4edb-be0c-0751e1de3843.png" width="600"/>


## Card visualisation changes
* New card type: `count`
* `&nbsp;` for long metric names & replace "-" to " "
* Changed card size

<img src="https://user-images.githubusercontent.com/1984175/217840981-6efc1efa-ecf6-46d4-902f-4bd4239b0850.png" width="600"/>


## Researched & added clearing metric and property name
<img src="https://user-images.githubusercontent.com/1984175/217864842-3349c39d-0de5-4d10-8927-bf8181bcc8c1.png" width="300"/>

## Tech: upgraded packages

## Fixed bug with updating visualisations when new metric adedd