### PR TITLE
Support CSV Export of Charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "license": "MIT",
     "scripts": {
         "dev": "parcel ./index.html --public-url ./",
-        "clean": "rm -rf ./dist/*",
+        "clean": "npm run clean:lin && npm run clean:win",
+        "clean:win": "node -e \"if (process.platform === 'win32') process.exit(1)\" || , if exist dist rmdir /Q /S dist",
+        "clean:lin": "node -e \"if (process.platform !== 'win32') process.exit(1)\" || rm -rf ./dist/* && echo linux",
         "build-css": "tailwindcss -i ./index.css -o ./output.css",
         "build": "npm run clean && npm run build-css && parcel build --public-url . --no-optimize index.html",
         "prod": "npm run clean && npm run build-css && parcel build --no-scope-hoist --public-url . index.html"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "license": "MIT",
     "scripts": {
         "dev": "parcel ./index.html --public-url ./",
-        "clean": "npm run clean:lin && npm run clean:win",
-        "clean:win": "node -e \"if (process.platform === 'win32') process.exit(1)\" || , if exist dist rmdir /Q /S dist",
-        "clean:lin": "node -e \"if (process.platform !== 'win32') process.exit(1)\" || rm -rf ./dist/* && echo linux",
+        "clean": "rm -rf ./dist/*",
         "build-css": "tailwindcss -i ./index.css -o ./output.css",
         "build": "npm run clean && npm run build-css && parcel build --public-url . --no-optimize index.html",
         "prod": "npm run clean && npm run build-css && parcel build --no-scope-hoist --public-url . index.html"


### PR DESCRIPTION
This PR implements CSV export of charts via a clickable link below the chart. The click also "edits" the block, which isn't ideal. `e.preventDefault()` doesn't seem to inhibit that, but it's possible I was doing that incorrectly.

The exported CSV can be loaded in Excel which will directly be able to interpret the dates, which is nice IMO. 

I've reverted a change I made to the build script so that it can be handled in a separate PR: #24 